### PR TITLE
Bugfix: no longer overwrite null SyncDiskPreset unless the Upgrade name matches 'private-eye'.

### DIFF
--- a/ByTheBook.csproj
+++ b/ByTheBook.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>ByTheBook</AssemblyName>
     <Description>A collection of modifications for the more scrupulous detective.</Description>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>
@@ -59,6 +59,8 @@
 
     <ZipDirectory
             SourceDirectory="$(ProjectDir)release\$(ProjectName)-$(Version)"
-            DestinationFile="$(ProjectDir)release\$(ProjectName)-$(Version).zip" />
+            DestinationFile="$(ProjectDir)release\$(ProjectName)-$(Version).zip"
+            Overwrite="TRUE"
+    />
   </Target>
 </Project>

--- a/ModFolderContent/CHANGELOG.md
+++ b/ModFolderContent/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.3
+
+* Fixed mod overwriting all other instances of sync disks.
+
 # 0.0.2
 
 * Fixed folder structure of DDS content. SyncDisk text should now render.

--- a/ModFolderContent/manifest.json
+++ b/ModFolderContent/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ByTheBook",
-  "version_number": "0.0.2",
+  "version_number": "0.0.3",
   "website_url": "https://github.com/wund3rcr4zy/by-the-book",
   "description": "Adds the 'Private Eye License' sync disk to the Weapons Locker. Allows for canvasing crime scenes without trespassing.",
   "dependencies": [

--- a/Patches/SaveStatePatches.cs
+++ b/Patches/SaveStatePatches.cs
@@ -18,12 +18,12 @@ namespace ByTheBook.Patches
             public static void Prefix(StateSaveData load)
             {
                 ByTheBookPlugin.Instance.DisableUpgrade(ByTheBookSyncEffects.PrivateEye);
-                foreach (var huh in load.upgrades)
+                foreach (var upgrade in load.upgrades)
                 {
-                    if (huh != null && huh.preset == null) 
+                    if (upgrade?.upgrade == PrivateEyeSyncDiskPreset.NAME && upgrade?.preset == null) 
                     {
                         ByTheBookPlugin.Logger.LogWarning($"SaveStateControllerHook: Hack Forcing PrivateEye preset. Really need to figure out why this happens.");
-                        huh.preset = PrivateEyeSyncDiskPreset.Instance;
+                        upgrade.preset = PrivateEyeSyncDiskPreset.Instance;
                         ByTheBookPlugin.Instance.EnableUpgrade(ByTheBookSyncEffects.PrivateEye);
                         break;
                     }

--- a/Patches/SyncDiskPatches.cs
+++ b/Patches/SyncDiskPatches.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static UpgradesController;
 
 namespace ByTheBook.Patches
 {
@@ -58,7 +59,7 @@ namespace ByTheBook.Patches
                 // TODO: figure out why the SyncDiskPreset is not present on the Upgrade.
                 // This issue is the root of other hackiness required in the code and why this mod
                 // can only support 1 sync disk as of now.
-                if (newUpgrade != null && newUpgrade.preset == null)
+                if (newUpgrade?.upgrade == PrivateEyeSyncDiskPreset.NAME && newUpgrade?.preset == null)
                 {
                     ByTheBookPlugin.Logger.LogWarning($"SyncDiskElementControllerHook: Hack Forcing PrivateEye preset. Really need to figure out why this happens.");
                     newUpgrade.preset = PrivateEyeSyncDiskPreset.Instance;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # by-the-book
 A Mod for the game 'Shadows of Doubt' by the Developer "ColePowered Games".
+
+Releases hosted on: https://thunderstore.io/c/shadows-of-doubt/


### PR DESCRIPTION
Related: https://github.com/wund3rcr4zy/by-the-book/issues/1