### PR TITLE
v0.2.2 — dialog crash guard + reliable enforcer "Talk To" + deterministic guest-pass (on upgrade)

### DIFF
--- a/ByTheBook.csproj
+++ b/ByTheBook.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>ByTheBook</AssemblyName>
     <Description>A collection of modifications for the more scrupulous detective.</Description>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/ByTheBook.csproj
+++ b/ByTheBook.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>ByTheBook</AssemblyName>
     <Description>A collection of modifications for the more scrupulous detective.</Description>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/ModFolderContent/CHANGELOG.md
+++ b/ModFolderContent/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.2.1
+
+* Stability: Sync Disk linkage hardening for **PrivateEye** (IL2CPP/Harmony); prevents rare NullReferenceExceptions in `SyncDiskElementController.Setup(...)` by late-linking the `SyncDiskPreset` before the row renders.
+* Robustness: Keeps `upgradesQuickRef` populated; relinks missing presets during `SetupQuickRef` and just before `UpdateUpgrades` to handle load-order edges.
+* Safety: If the preset still can’t be resolved after late-link, the original `Setup(...)` is skipped to avoid an NRE.
+* Internals: Resource scan now ignores hidden/internal objects; added extra null guards; quick-ref postfix uses a low Harmony priority to better cooperate with other mods.
+* Utility: `BTB_UpgradeEffectRefresh.ForceRefresh()` helper to trigger `OnSyncDiskChange(true)` after programmatic install/uninstall.
+
 # 0.2.0
 
 * Bugfix: the player should no longer become very tall and fall through the floor on the second upgrade of PrivateEye. (Fingers crossed. That one was weird)

--- a/ModFolderContent/CHANGELOG.md
+++ b/ModFolderContent/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.2.2
+
+* Stability: defensive null-guard for `DialogController.TestSpecialCaseAvailability(...)`.
+  * Prefix (Priority.First) returns `false` when `preset`/`saysTo` is null or destroyed (prevents NREs during dialog teardown).
+  * Finalizer swallows any exception from other patches/original and sets `__result = false` instead of crashing.
+  * Error-only logging (release-friendly).
+* UX: ensure **“Talk To”** reliably appears for *on-duty* enforcers at active crime scenes.
+  * Postfix on `Interactable.UpdateCurrentActions` (no changes if dialog is open).
+  * IL2CPP-safe iteration of `aiActionReference` to find the canonical Talk action; promoted to **PRIMARY** via `InteractableCurrentAction`.
+* Gameplay: make guest-pass requests deterministic **after the upgrade**.
+  * In `DialogController.ExecuteDialog` (Guard Guest Pass branch), force success only when `CrimeSceneGuestPass` effect is active; otherwise keep the original RNG.
+
 # 0.2.1
 
 * Stability: Sync Disk linkage hardening for **PrivateEye** (IL2CPP/Harmony); prevents rare NullReferenceExceptions in `SyncDiskElementController.Setup(...)` by late-linking the `SyncDiskPreset` before the row renders.

--- a/ModFolderContent/manifest.json
+++ b/ModFolderContent/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ByTheBook",
-  "version_number": "0.2.1",
+  "version_number": "0.2.2",
   "website_url": "https://github.com/wund3rcr4zy/by-the-book",
   "description": "Adds the 'Private Eye License' sync disk to the Weapons Locker. Allows for canvasing crime scenes without trespassing.",
   "dependencies": [

--- a/ModFolderContent/manifest.json
+++ b/ModFolderContent/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ByTheBook",
-  "version_number": "0.2.0",
+  "version_number": "0.2.1",
   "website_url": "https://github.com/wund3rcr4zy/by-the-book",
   "description": "Adds the 'Private Eye License' sync disk to the Weapons Locker. Allows for canvasing crime scenes without trespassing.",
   "dependencies": [

--- a/Patches/DialogControllerNullGuardPatches.cs
+++ b/Patches/DialogControllerNullGuardPatches.cs
@@ -1,0 +1,81 @@
+// Patches/DialogControllerNullGuardPatches.cs
+// v0.2.1 — Crash guard for DialogController.TestSpecialCaseAvailability
+//
+// Why: Other patches may dereference `preset.name`. During dialog teardown,
+//      the game can legitimately call this with a null/destroyed `preset`,
+//      causing an NRE and a crash.
+//
+// What this does:
+//   • Prefix (Priority.First): if `preset` (or `saysTo`) is null/destroyed,
+//     short-circuit with __result=false so the option is simply unavailable.
+//   • Finalizer: catch any exception from other prefixes/original and turn it
+//     into __result=false instead of a crash.
+//
+// Logging: error-only (release-friendly).
+
+#nullable enable
+using System;
+using HarmonyLib;
+using UnityEngine;
+using BepInEx.Logging;
+
+internal static class BTB_DialogGuardLog
+{
+    private static ManualLogSource? _log;
+    public static ManualLogSource Log =>
+        _log ??= BepInEx.Logging.Logger.CreateLogSource("ByTheBook");
+    public static void Err(string msg) => Log.LogError(msg);
+}
+
+[HarmonyPatch(typeof(DialogController), nameof(DialogController.TestSpecialCaseAvailability))]
+static class BTB_DialogController_TestSpecialCaseAvailability_Guard
+{
+    // Run first so we can safely short-circuit on invalid args.
+    [HarmonyPrefix, HarmonyPriority(Priority.First)]
+    static bool Prefix(ref bool __result, DialogPreset preset, Citizen saysTo, SideJob jobRef)
+    {
+        try
+        {
+            // Unity "truthy" check: destroyed objects compare equal to null.
+            if (preset == null || !preset)
+            {
+                __result = false;   // option not available → no crash
+                return false;       // skip original
+            }
+
+            if (saysTo == null || !saysTo)
+            {
+                __result = false;
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Extremely defensive: if our guard fails, still avoid the call chain.
+            BTB_DialogGuardLog.Err($"[BTB] Dialog guard prefix failed: {ex}");
+            __result = false;
+            return false;
+        }
+
+        return true; // continue to other patches/original
+    }
+
+    // Final safety net: swallow any exception and downgrade to "not available".
+    [HarmonyFinalizer]
+    static Exception? Finalizer(Exception __exception, ref bool __result)
+    {
+        if (__exception != null)
+        {
+            try
+            {
+                BTB_DialogGuardLog.Err($"[BTB] Suppressed dialog availability exception: {__exception}");
+            }
+            catch { /* avoid recursive logging issues */ }
+
+            __result = false;
+            return null; // swallow the exception
+        }
+
+        return null;
+    }
+}

--- a/Patches/DialogControllerPatches.cs
+++ b/Patches/DialogControllerPatches.cs
@@ -44,6 +44,12 @@ namespace ByTheBook.Patches
                                 double successChance = 0.99 - Math.Clamp((socialCreditNumerator / guardPassSocialCreditRequired), 0, 0.75);
                                 double randomDouble = random.NextDouble();
                                 success = (randomDouble >= successChance);
+                                // FIX: Force success only when the upgrade's ALWAYS-PASS effect is enabled.
+                                // Base disk enables GuardGuestPass (dialog available). The upgrade enables CrimeSceneGuestPass (guaranteed pass).
+                                if (ByTheBookUpgradeManager.Instance.IsEffectEnabled(SyncDisks.ByTheBookSyncEffects.CrimeSceneGuestPass))
+                                {
+                                    success = true;
+                                }
                                 ByTheBook.ByTheBookPlugin.Logger.LogInfo($"GuardIssueGuestPass rolled: {randomDouble} - required: {successChance}");
                                 break;
                         }

--- a/Patches/EnforcerTalkAccessPatches.cs
+++ b/Patches/EnforcerTalkAccessPatches.cs
@@ -1,12 +1,43 @@
 // Patches/EnforcerTalkAccessPatches.cs
-// v0.2.1 — Ensure “Talk To” appears for on-duty enforcers (any active crime scene)
-//           without touching actions while the dialog UI is open.
+// v0.2.2 — Ensure “Talk To” appears for on-duty enforcers (active crime scenes) without
+//           touching action maps while the dialog UI is open (IL2CPP-safe).
 //
-// What this does
-//  • Skips changes when a dialog is open (avoid race with End Conversation).
-//  • Finds the guard’s existing Talk InteractionAction from aiActionReference (IL2CPP dict).
-//  • Wraps it into Interactable.InteractableCurrentAction and promotes to PRIMARY.
-//  • Error-only logging (release-friendly).
+// OVERVIEW
+// ──────────────────────────────────────────────────────────────────────────────
+// Some enforcers guarding an active crime scene lack the “Talk To” prompt even
+// though the base game exposes it via their AI action map. This patch ensures
+// the prompt reliably appears for *on-duty* enforcers while avoiding races with
+// the dialog UI lifecycle (which can crash if action maps are mutated mid-dialog).
+//
+// WHAT THIS PATCH DOES
+// ─ Ensures we only act when the target is an *on-duty* enforcer guarding the
+//   current crime scene.
+// ─ Skips any mutations when the dialog UI is open/tearing down (prevents “End
+//   Conversation” crashes).
+// ─ Finds the canonical “Talk” InteractionAction from the NPC’s
+//   aiActionReference (an IL2CPP Dictionary) and promotes it to PRIMARY by
+//   wrapping it in InteractableCurrentAction (no string/locale dependency).
+// ─ Keeps logging error-only in release builds.
+//
+// IL2CPP NOTES
+// ─ Unity IL2CPP collections live under Il2CppSystem.Collections.Generic.
+//   Iterate their ValueCollection/Enumerator directly (do not cast to
+//   System.Collections.*). This file does exactly that for aiActionReference.
+//
+// SCOPE & SAFETY
+// ─ Postfix on Interactable.UpdateCurrentActions: conservative, runs after the
+//   game builds the map. No changes if guard isn’t on duty, or if dialog is open.
+// ─ No string matching beyond a single “talk” substring check on the action’s
+//   ToString() (the source object is the game’s InteractionAction).
+//
+// VERSION HISTORY
+// ─ 0.2.2  • On-duty guard detection via GameplayController.enforcerCalls.
+//          • Dialog-open guard to avoid mutating actions during dialog teardown.
+//          • IL2CPP-safe iteration of aiActionReference.ValueCollection (no casts to System.*).
+//          • Promotion of the canonical Talk action to PRIMARY using
+//            Interactable.InteractableCurrentAction (visible + enabled).
+//          • Error-only logging in release builds.
+//          • Header/docs refresh for PR review clarity.
 
 #nullable enable
 using System;
@@ -14,8 +45,9 @@ using HarmonyLib;
 using UnityEngine;
 using BepInEx.Logging;
 // IL2CPP collections live here; iterate them directly (don’t cast to System.Collections.*)
-using Il2CppSystem.Collections.Generic; // Enumerator<>, Dictionary<,> etc.  (see example mods) [ref]
+using Il2CppSystem.Collections.Generic; // Enumerator<>, Dictionary<,> etc.
 
+/// <summary>Release-friendly logger: errors only.</summary>
 internal static class BTB_TalkLog
 {
     private static ManualLogSource? _log;
@@ -23,8 +55,10 @@ internal static class BTB_TalkLog
     public static void Err(string msg) => Log.LogError(msg);
 }
 
+/// <summary>Helpers for identifying on-duty guards and safely surfacing “Talk”.</summary>
 internal static class BTB_EnforcerTalk
 {
+    /// <summary>True if this citizen is the assigned guard for any active crime scene.</summary>
     public static bool IsOnDutyCrimeSceneGuard(Citizen? guard)
     {
         try
@@ -50,7 +84,7 @@ internal static class BTB_EnforcerTalk
         return false;
     }
 
-    // Best-effort: don’t mutate actions while dialog UI is open/closing.
+    /// <summary>Best-effort guard: don’t mutate while dialog UI is open/tearing down.</summary>
     public static bool IsDialogOpen()
     {
         try
@@ -58,7 +92,7 @@ internal static class BTB_EnforcerTalk
             var dc = (DialogController._instance != null) ? DialogController._instance : DialogController.Instance;
             if (dc == null) return false;
 
-            // Try common flags; ignore if not present on this build.
+            // Different builds expose different flags; try both reflectively.
             try { if ((bool)(dc.GetType().GetProperty("isOpen")?.GetValue(dc) ?? false)) return true; } catch { }
             try { if ((bool)(dc.GetType().GetProperty("dialogOpen")?.GetValue(dc) ?? false)) return true; } catch { }
         }
@@ -66,10 +100,14 @@ internal static class BTB_EnforcerTalk
         return false;
     }
 
+    /// <summary>Loose “talk” identifier; we check the game action’s own label.</summary>
     static bool IsTalkLabel(string? s)
         => !string.IsNullOrEmpty(s) && s.IndexOf("talk", StringComparison.OrdinalIgnoreCase) >= 0;
 
-    /// Find the *InteractionAction* for Talk in aiActionReference (IL2CPP Dictionary<AIActionPreset, InteractionAction>).
+    /// <summary>
+    /// Fetch the canonical Talk InteractionAction from aiActionReference
+    /// (IL2CPP Dictionary&lt;AIActionPreset, InteractionAction&gt;).
+    /// </summary>
     public static bool TryGetTalkActionFromAIRef(Interactable i, out InteractablePreset.InteractionAction? action)
     {
         action = null;
@@ -78,9 +116,9 @@ internal static class BTB_EnforcerTalk
             var dict = i.aiActionReference; // Il2CppSystem.Collections.Generic.Dictionary<AIActionPreset, InteractionAction>
             if (dict == null) return false;
 
-            // Iterate the IL2CPP ValueCollection directly — NO casts to System.* IEnumerable.
+            // Iterate IL2CPP ValueCollection directly — no casts to System.Collections.*.
             var values = dict.Values; // ValueCollection<InteractionAction>
-            var e = values.GetEnumerator(); // Il2CppSystem.Collections.Generic.Enumerator<InteractionAction>
+            var e = values.GetEnumerator(); // Enumerator<InteractionAction>
             while (e.MoveNext())
             {
                 var a = e.Current;
@@ -98,6 +136,7 @@ internal static class BTB_EnforcerTalk
         return false;
     }
 
+    /// <summary>Wrap a game InteractionAction into a visible, enabled current action.</summary>
     public static Interactable.InteractableCurrentAction MakeCurrent(InteractablePreset.InteractionAction action)
         => new Interactable.InteractableCurrentAction
         {
@@ -107,6 +146,10 @@ internal static class BTB_EnforcerTalk
         };
 }
 
+/// <summary>
+/// Postfix: after the game builds currentActions, promote the guard’s “Talk” action
+/// to PRIMARY — but only if it’s safe (no dialog open) and only for on-duty guards.
+/// </summary>
 [HarmonyPatch(typeof(Interactable), nameof(Interactable.UpdateCurrentActions))]
 static class BTB_EnsureEnforcerTalk_Postfix
 {
@@ -116,7 +159,7 @@ static class BTB_EnsureEnforcerTalk_Postfix
         {
             if (__instance == null) return;
 
-            // Don’t touch action maps while dialog is open (prevents End Conversation crashes).
+            // Prevent race with dialog teardown (“End Conversation”) by skipping while open.
             if (BTB_EnforcerTalk.IsDialogOpen()) return;
 
             var citizen = __instance.belongsTo as Citizen;

--- a/Patches/EnforcerTalkAccessPatches.cs
+++ b/Patches/EnforcerTalkAccessPatches.cs
@@ -1,19 +1,16 @@
 // Patches/EnforcerTalkAccessPatches.cs
-// v0.2.1 — Ensure “Talk To” appears for on-duty enforcers (any active crime scene).
+// v0.2.1 — Ensure “Talk To” appears for on-duty enforcers (any active crime scene)
+//           without touching actions while the dialog UI is open.
 //
 // What this does
-//  - After Interactable.UpdateCurrentActions builds a target’s action list,
-//    if the target is an Enforcer *guarding any active crime scene*, we make sure
-//    the “Talk To” action is available and visible:
-//      • First, try re-enabling it via SetActionDisable("Talk To", false).
-//      • If a talk action already exists on another slot, promote it to PRIMARY.
-//      • If it exists in disabledActions, surface it to PRIMARY.
-//  - Writes the correct wrapper type (Interactable.InteractableCurrentAction)
-//    into currentActions; avoids System<> vs Il2CppSystem<> KeyValuePair mismatches.
-//  - Error-only logging (release-friendly).
+//  • Skips changes when a dialog is open (avoid race with End Conversation).
+//  • Finds the guard’s existing Talk InteractionAction from aiActionReference.
+//  • Wraps it into Interactable.InteractableCurrentAction and promotes to PRIMARY.
+//  • Error-only logging (release-friendly).
 
 #nullable enable
 using System;
+using System.Collections;
 using HarmonyLib;
 using UnityEngine;
 using BepInEx.Logging;
@@ -27,7 +24,6 @@ internal static class BTB_TalkLog
 
 internal static class BTB_EnforcerTalk
 {
-    /// <summary>Is this citizen guarding ANY active taped-off crime scene right now?</summary>
     public static bool IsOnDutyCrimeSceneGuard(Citizen? guard)
     {
         try
@@ -42,57 +38,85 @@ internal static class BTB_EnforcerTalk
             var calls = gc.enforcerCalls;
             if (calls == null) return false;
 
-            foreach (var kv in calls) // e.g., Dictionary<NewGameLocation, EnforcerCall>
+            foreach (var kv in calls)
             {
                 var call = kv.Value;
-                if (call == null) continue;
-
-                // Typical fields on EnforcerCall:
-                //   isCrimeScene : bool
-                //   guard        : int (humanID)
-                if (call.isCrimeScene && call.guard == guard.humanID)
+                if (call != null && call.isCrimeScene && call.guard == guard.humanID)
                     return true;
             }
         }
-        catch (Exception ex)
-        {
-            BTB_TalkLog.Err($"[BTB] On-duty check failed: {ex}");
-        }
+        catch (Exception ex) { BTB_TalkLog.Err($"[BTB] On-duty check failed: {ex}"); }
         return false;
+    }
+
+    // Best-effort: don’t mutate actions while dialog UI is open/closing.
+    public static bool IsDialogOpen()
+    {
+        try
+        {
+            var dc = (DialogController._instance != null) ? DialogController._instance : DialogController.Instance;
+            if (dc == null) return false;
+
+            // Different builds expose different flags; try both safely.
+            try { if ((bool)AccessProp(dc, "isOpen")) return true; } catch { }
+            try { if ((bool)AccessProp(dc, "dialogOpen")) return true; } catch { }
+        }
+        catch { }
+        return false;
+    }
+
+    // Tiny helper to read a property safely without hard type deps
+    static object? AccessProp(object obj, string name)
+    {
+        try { return obj.GetType().GetProperty(name)?.GetValue(obj); } catch { return null; }
     }
 
     static bool IsTalkLabel(string? s)
-        => !string.IsNullOrEmpty(s) &&
-           s.IndexOf("talk", StringComparison.OrdinalIgnoreCase) >= 0;
+        => !string.IsNullOrEmpty(s) && s.IndexOf("talk", StringComparison.OrdinalIgnoreCase) >= 0;
 
-    /// <summary>
-    /// Look for an already-present talk action in currentActions.
-    /// Returns the InteractableCurrentAction (avoids KeyValuePair type issues).
-    /// </summary>
-    public static bool TryFindExistingTalk(
-        Interactable i,
-        out Interactable.InteractableCurrentAction? found)
+    /// Find the *InteractionAction* for Talk in aiActionReference.
+    public static bool TryGetTalkActionFromAIRef(Interactable i, out InteractablePreset.InteractionAction? action)
     {
-        found = null;
-
-        var dict = i.currentActions; // Il2CppSystem.Collections.Generic.Dictionary<InteractionKey, InteractableCurrentAction>
-        if (dict == null) return false;
-
-        // Iterate values to avoid dealing with Il2Cpp KeyValuePair generics.
-        foreach (var cur in dict.Values)
+        action = null;
+        try
         {
-            if (cur == null) continue;
-            var label = cur.currentAction?.ToString();
-            if (IsTalkLabel(label))
+            var dictObj = i.aiActionReference;       // usually Dictionary<InteractablePreset.InteractionAction, …>
+            if (dictObj == null) return false;
+
+            // Use non-generic IDictionary shape to avoid Il2Cpp KeyValuePair types.
+            if (dictObj is IDictionary dict)
             {
-                found = cur;
-                return true;
+                foreach (DictionaryEntry de in dict)
+                {
+                    var key = de.Key as InteractablePreset.InteractionAction;
+                    if (key == null) continue;
+                    if (IsTalkLabel(key.ToString()))
+                    {
+                        action = key;
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                foreach (var entry in (IEnumerable)dictObj)
+                {
+                    dynamic e = entry;
+                    object? keyObj = null;
+                    try { keyObj = e.Key; } catch { }
+                    var key = keyObj as InteractablePreset.InteractionAction;
+                    if (key != null && IsTalkLabel(key.ToString()))
+                    {
+                        action = key;
+                        return true;
+                    }
+                }
             }
         }
+        catch (Exception ex) { BTB_TalkLog.Err($"[BTB] TryGetTalkActionFromAIRef failed: {ex}"); }
         return false;
     }
 
-    /// <summary>Build the wrapper type the UI expects.</summary>
     public static Interactable.InteractableCurrentAction MakeCurrent(InteractablePreset.InteractionAction action)
         => new Interactable.InteractableCurrentAction
         {
@@ -100,24 +124,6 @@ internal static class BTB_EnforcerTalk
             display = true,
             enabled = true
         };
-
-    /// <summary>If talk exists in disabledActions, surface it to PRIMARY.</summary>
-    public static bool TrySurfaceFromDisabled(Interactable i)
-    {
-        var list = i.disabledActions; // (Il2Cpp) List<InteractablePreset.InteractionAction>
-        if (list == null) return false;
-
-        foreach (var a in list)
-        {
-            if (a == null) continue;
-            if (IsTalkLabel(a.ToString()))
-            {
-                i.currentActions[InteractablePreset.InteractionKey.primary] = MakeCurrent(a);
-                return true;
-            }
-        }
-        return false;
-    }
 }
 
 [HarmonyPatch(typeof(Interactable), nameof(Interactable.UpdateCurrentActions))]
@@ -129,24 +135,19 @@ static class BTB_EnsureEnforcerTalk_Postfix
         {
             if (__instance == null) return;
 
+            // Don’t touch action maps while dialog is open (prevents End Conversation crashes).
+            if (BTB_EnforcerTalk.IsDialogOpen()) return;
+
             var citizen = __instance.belongsTo as Citizen;
             if (citizen == null) return;
             if (!BTB_EnforcerTalk.IsOnDutyCrimeSceneGuard(citizen)) return;
 
-            // Zero-risk re-enable by label (no-op if locale differs or method absent).
-            try { __instance.SetActionDisable("Talk To", false); } catch { }
-
-            // If a talk action is already present, make it visible/enabled and move it to PRIMARY.
-            if (BTB_EnforcerTalk.TryFindExistingTalk(__instance, out var current) && current != null)
+            // Light, locale-agnostic enable: obtain the Talk InteractionAction from AI ref and surface it.
+            if (BTB_EnforcerTalk.TryGetTalkActionFromAIRef(__instance, out var talk) && talk != null)
             {
-                current.display = true;
-                current.enabled = true;
-                __instance.currentActions[InteractablePreset.InteractionKey.primary] = current;
-                return;
+                __instance.currentActions[InteractablePreset.InteractionKey.primary] =
+                    BTB_EnforcerTalk.MakeCurrent(talk);
             }
-
-            // Otherwise, if it's in disabledActions, surface it.
-            BTB_EnforcerTalk.TrySurfaceFromDisabled(__instance);
         }
         catch (Exception ex)
         {

--- a/Patches/EnforcerTalkAccessPatches.cs
+++ b/Patches/EnforcerTalkAccessPatches.cs
@@ -1,0 +1,156 @@
+// Patches/EnforcerTalkAccessPatches.cs
+// v0.2.1 — Ensure “Talk To” appears for on-duty enforcers (any active crime scene).
+//
+// What this does
+//  - After Interactable.UpdateCurrentActions builds a target’s action list,
+//    if the target is an Enforcer *guarding any active crime scene*, we make sure
+//    the “Talk To” action is available and visible:
+//      • First, try re-enabling it via SetActionDisable("Talk To", false).
+//      • If a talk action already exists on another slot, promote it to PRIMARY.
+//      • If it exists in disabledActions, surface it to PRIMARY.
+//  - Writes the correct wrapper type (Interactable.InteractableCurrentAction)
+//    into currentActions; avoids System<> vs Il2CppSystem<> KeyValuePair mismatches.
+//  - Error-only logging (release-friendly).
+
+#nullable enable
+using System;
+using HarmonyLib;
+using UnityEngine;
+using BepInEx.Logging;
+
+internal static class BTB_TalkLog
+{
+    private static ManualLogSource? _log;
+    public static ManualLogSource Log => _log ??= BepInEx.Logging.Logger.CreateLogSource("ByTheBook");
+    public static void Err(string msg) => Log.LogError(msg);
+}
+
+internal static class BTB_EnforcerTalk
+{
+    /// <summary>Is this citizen guarding ANY active taped-off crime scene right now?</summary>
+    public static bool IsOnDutyCrimeSceneGuard(Citizen? guard)
+    {
+        try
+        {
+            if (guard == null || !guard.isEnforcer) return false;
+
+            var gc = GameplayController._instance != null
+                ? GameplayController._instance
+                : GameplayController.Instance;
+            if (gc == null) return false;
+
+            var calls = gc.enforcerCalls;
+            if (calls == null) return false;
+
+            foreach (var kv in calls) // e.g., Dictionary<NewGameLocation, EnforcerCall>
+            {
+                var call = kv.Value;
+                if (call == null) continue;
+
+                // Typical fields on EnforcerCall:
+                //   isCrimeScene : bool
+                //   guard        : int (humanID)
+                if (call.isCrimeScene && call.guard == guard.humanID)
+                    return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            BTB_TalkLog.Err($"[BTB] On-duty check failed: {ex}");
+        }
+        return false;
+    }
+
+    static bool IsTalkLabel(string? s)
+        => !string.IsNullOrEmpty(s) &&
+           s.IndexOf("talk", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    /// <summary>
+    /// Look for an already-present talk action in currentActions.
+    /// Returns the InteractableCurrentAction (avoids KeyValuePair type issues).
+    /// </summary>
+    public static bool TryFindExistingTalk(
+        Interactable i,
+        out Interactable.InteractableCurrentAction? found)
+    {
+        found = null;
+
+        var dict = i.currentActions; // Il2CppSystem.Collections.Generic.Dictionary<InteractionKey, InteractableCurrentAction>
+        if (dict == null) return false;
+
+        // Iterate values to avoid dealing with Il2Cpp KeyValuePair generics.
+        foreach (var cur in dict.Values)
+        {
+            if (cur == null) continue;
+            var label = cur.currentAction?.ToString();
+            if (IsTalkLabel(label))
+            {
+                found = cur;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Build the wrapper type the UI expects.</summary>
+    public static Interactable.InteractableCurrentAction MakeCurrent(InteractablePreset.InteractionAction action)
+        => new Interactable.InteractableCurrentAction
+        {
+            currentAction = action,
+            display = true,
+            enabled = true
+        };
+
+    /// <summary>If talk exists in disabledActions, surface it to PRIMARY.</summary>
+    public static bool TrySurfaceFromDisabled(Interactable i)
+    {
+        var list = i.disabledActions; // (Il2Cpp) List<InteractablePreset.InteractionAction>
+        if (list == null) return false;
+
+        foreach (var a in list)
+        {
+            if (a == null) continue;
+            if (IsTalkLabel(a.ToString()))
+            {
+                i.currentActions[InteractablePreset.InteractionKey.primary] = MakeCurrent(a);
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+[HarmonyPatch(typeof(Interactable), nameof(Interactable.UpdateCurrentActions))]
+static class BTB_EnsureEnforcerTalk_Postfix
+{
+    static void Postfix(Interactable __instance)
+    {
+        try
+        {
+            if (__instance == null) return;
+
+            var citizen = __instance.belongsTo as Citizen;
+            if (citizen == null) return;
+            if (!BTB_EnforcerTalk.IsOnDutyCrimeSceneGuard(citizen)) return;
+
+            // Zero-risk re-enable by label (no-op if locale differs or method absent).
+            try { __instance.SetActionDisable("Talk To", false); } catch { }
+
+            // If a talk action is already present, make it visible/enabled and move it to PRIMARY.
+            if (BTB_EnforcerTalk.TryFindExistingTalk(__instance, out var current) && current != null)
+            {
+                current.display = true;
+                current.enabled = true;
+                __instance.currentActions[InteractablePreset.InteractionKey.primary] = current;
+                return;
+            }
+
+            // Otherwise, if it's in disabledActions, surface it.
+            BTB_EnforcerTalk.TrySurfaceFromDisabled(__instance);
+        }
+        catch (Exception ex)
+        {
+            BTB_TalkLog.Err($"[BTB] EnsureEnforcerTalk failed: {ex}");
+        }
+    }
+}

--- a/Patches/UpgradesLinkerPatches.cs
+++ b/Patches/UpgradesLinkerPatches.cs
@@ -1,0 +1,292 @@
+/*
+ *  UpgradesLinkerPatches.cs
+ *  v0.2.1 — “By-the-Book” sync-disk linkage hardening (IL2CPP / Harmony)
+ *
+ *  WHAT THIS DOES
+ *  ─────────────────────────────────────────────────────────────────────────────
+ *  Fixes a race where the Sync Disk UI row is built before a custom disk’s
+ *  SyncDiskPreset is linked to its Upgrades row, causing NREs in
+ *  SyncDiskElementController.Setup(...). We ensure the preset is resolvable from
+ *  UpgradesController.upgradesQuickRef and “late-link” it if necessary before
+ *  the UI reads from it. We also keep the quickRef populated across screen
+ *  opens so your disk always renders correctly.
+ *
+ *  GAME API TOUCHPOINTS
+ *  ─────────────────────────────────────────────────────────────────────────────
+ *  • UpgradesController
+ *      - SetupQuickRef(): ensure our preset exists in upgradesQuickRef and
+ *        opportunistically relink any rows that loaded without a preset.
+ *      - UpdateUpgrades(): pre-pass to relink rows created after SetupQuickRef
+ *        (robust against load order).
+ *      - Fields used: upgrades (List<Upgrades>), spawnedDisks (List<SyncDiskElementController>),
+ *        upgradesQuickRef (Dictionary<string, SyncDiskPreset>), isOpen, _instance.
+ *
+ *  • SyncDiskElementController
+ *      - Setup(Upgrades newUpgrade): late-link the preset in case it arrived
+ *        null, then allow the original Setup to run. While diagnosing, we
+ *        skip the original if the preset is still missing to prevent an NRE.
+ *
+ *  • UpgradeEffectController
+ *      - Utility: ForceRefresh() calls OnSyncDiskChange(true) for a clean,
+ *        official state refresh after programmatic installs/uninstalls.
+ *
+ *  HOW TO USE / TWEAK
+ *  ─────────────────────────────────────────────────────────────────────────────
+ *  • Upgrade key: by default this file targets the “private-eye” disk via
+ *    BTB_UpgradesLinker.UpgradeKey. If you rename the disk, update that
+ *    constant to your new key (must match Upgrades.upgrade).
+ *
+ *  • Logging: Info/Warn/Debug are compiled out in Release via [Conditional("DEBUG")].
+ *    Errors (exceptions) are always logged.
+ *
+ *  • Safety guard: the Setup() prefix currently skips the original method if
+ *    the preset is still null *after* late-linking. Once your logs show it’s
+ *    always resolved, you can remove that early-return to reduce noise.
+ *
+ *  • One-liner late-link: BTB_LinkHelpers.LateLinkPreset(u) uses TryGetValue
+ *    (Unity-friendly) and null-coalescing assignment (??=) to attach the
+ *    preset only when missing.
+ *
+ *  COMPATIBILITY / ASSUMPTIONS
+ *  ─────────────────────────────────────────────────────────────────────────────
+ *  • BepInEx 6 (IL2CPP) + Harmony.
+ *  • Uses Il2CppInterop and Unity 2021 APIs; no modern BCL extensions required.
+ *  • Does not change vanilla behavior for other disks; only fills in missing
+ *    preset references and protects against early UI reads.
+ *
+ *  VERSIONING / NOTES
+ *  ─────────────────────────────────────────────────────────────────────────────
+ *  • 0.2.1  One-liner helper, pre-/post-hooks, and diagnostic breadcrumbs; prevents
+ *           NRE in SyncDiskElementController.Setup when presets are late. Also includes
+ *           zero-risk tweaks: filter hidden/internal objects in the Resources scan,
+ *           extra null guards, and a low Harmony priority hint on the quick-ref patch.
+ */
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics; // ConditionalAttribute
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using UnityEngine;
+using BepInEx.Logging; // ManualLogSource
+
+// Local logger proxy without depending on your plugin class.
+// In Release builds, Info/Warn/Debug calls are compiled out entirely.
+internal static class BTB_Log
+{
+    private static ManualLogSource? _log;
+    public static ManualLogSource Log =>
+        _log ??= BepInEx.Logging.Logger.CreateLogSource("ByTheBook"); // fully-qualified to avoid CS0104
+
+    [Conditional("DEBUG")] public static void Info(string msg) => Log.LogInfo(msg);
+    [Conditional("DEBUG")] public static void Warn(string msg) => Log.LogWarning(msg);
+    [Conditional("DEBUG")] public static void Debug(string msg) => Log.LogDebug(msg);
+
+    // Always-on for exception paths
+    public static void Error(string msg) => Log.LogError(msg);
+}
+
+public static class BTB_UpgradesLinker
+{
+    public const string UpgradeKey = "private-eye";  // MUST match UpgradesController.Upgrades.upgrade
+
+    // Set this from your factory if you build the preset in code.
+    public static SyncDiskPreset? CachedPreset;
+
+    [Conditional("DEBUG")] public static void LogInfo(string msg) => BTB_Log.Info(msg);
+    [Conditional("DEBUG")] public static void LogWarn(string msg) => BTB_Log.Warn(msg);
+    public static void LogErr(string msg)  => BTB_Log.Error(msg);
+    [Conditional("DEBUG")] public static void LogDbg(string msg)  => BTB_Log.Debug(msg);
+
+    public static SyncDiskPreset? GetOrFindPreset()
+    {
+        if (CachedPreset != null)
+        {
+            if (CachedPreset) return CachedPreset; // Unity "truthy" check
+            CachedPreset = null; // stale destroyed ref
+        }
+
+        try
+        {
+            // One-time scan during boot/setup is fine (very slow; don't do every frame).
+            // Filter out hidden/internal objects to avoid odd picks.
+            var all = Resources.FindObjectsOfTypeAll<SyncDiskPreset>();
+            foreach (var p in all)
+            {
+                if (!p || p.hideFlags != HideFlags.None) continue; // ignore internal/hidden
+                if (string.Equals(p.name, UpgradeKey, StringComparison.Ordinal))
+                {
+                    CachedPreset = p;
+#if DEBUG
+                    LogInfo($"[BTB] Found SyncDiskPreset in resources: '{p.name}'.");
+#endif
+                    return CachedPreset;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LogErr($"[BTB] Error scanning for SyncDiskPreset: {ex}");
+        }
+
+#if DEBUG
+        LogWarn($"[BTB] Could not find SyncDiskPreset by name '{UpgradeKey}'. If you create it in code, set BTB_UpgradesLinker.CachedPreset after creation.");
+#endif
+        return null;
+    }
+
+    public static int RelinkMissingPresets(UpgradesController uc)
+    {
+        if (uc == null || uc.upgrades == null) return 0;
+
+        int fixedCount = 0;
+        try
+        {
+            foreach (var u in uc.upgrades)
+            {
+                if (u == null) continue;
+                if (u.preset != null) continue;
+                if (string.IsNullOrEmpty(u.upgrade)) continue;
+
+                if (uc.upgradesQuickRef.TryGetValue(u.upgrade, out var p) && p != null)
+                {
+                    u.preset = p;
+                    fixedCount++;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            LogErr($"[BTB] Exception while relinking presets: {ex}");
+        }
+        return fixedCount;
+    }
+
+    public static void Dump(UpgradesController uc, string when)
+    {
+#if DEBUG
+        try
+        {
+            var keys = string.Join(", ", uc.upgradesQuickRef.Keys);
+            LogDbg($"[BTB] quickRef keys {when}: {keys}");
+
+            foreach (var u in uc.upgrades)
+            {
+                if (u == null) continue;
+                var presetName = u.preset ? u.preset.name : "null";
+                LogDbg($"[BTB] row {when}: upgrade='{u.upgrade}', preset='{presetName}', state={u.state}, level={u.level}");
+            }
+        }
+        catch (Exception ex)
+        {
+            LogErr($"[BTB] Dump error: {ex}");
+        }
+#endif
+    }
+}
+
+// --- ONE-LINER HELPER ---
+internal static class BTB_LinkHelpers
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void LateLinkPreset(UpgradesController.Upgrades u)
+        => u.preset ??=
+            (UpgradesController._instance != null
+             && !string.IsNullOrEmpty(u.upgrade)
+             && UpgradesController._instance.upgradesQuickRef.TryGetValue(u.upgrade, out var p))
+            ? p
+            : null;
+}
+
+// Ensure the preset exists in quickRef + relink after quickRef is built
+[HarmonyPatch(typeof(UpgradesController), nameof(UpgradesController.SetupQuickRef))]
+[HarmonyPriority(HarmonyLib.Priority.Low)] // ordering hint only (safe)
+static class BTB_LinkPresetIntoQuickRef_Postfix
+{
+    static void Postfix(UpgradesController __instance)
+    {
+        if (__instance == null) return;
+
+        if (!__instance.upgradesQuickRef.TryGetValue(BTB_UpgradesLinker.UpgradeKey, out var preset) || preset == null)
+        {
+            var p = BTB_UpgradesLinker.GetOrFindPreset();
+            if (p != null)
+            {
+                __instance.upgradesQuickRef[BTB_UpgradesLinker.UpgradeKey] = p;
+                BTB_UpgradesLinker.LogInfo($"[BTB] Registered '{BTB_UpgradesLinker.UpgradeKey}' in upgradesQuickRef.");
+            }
+            else
+            {
+                BTB_UpgradesLinker.LogWarn($"[BTB] Preset for '{BTB_UpgradesLinker.UpgradeKey}' unavailable during SetupQuickRef.");
+            }
+        }
+
+        int relinked = BTB_UpgradesLinker.RelinkMissingPresets(__instance);
+        if (relinked > 0)
+            BTB_UpgradesLinker.LogInfo($"[BTB] Linked {relinked} upgrade row(s) to their SyncDiskPreset.");
+
+        BTB_UpgradesLinker.Dump(__instance, "after-SetupQuickRef");
+    }
+}
+
+// Relink just before the UI rebuilds, to catch rows created after SetupQuickRef runs.
+[HarmonyPatch(typeof(UpgradesController), nameof(UpgradesController.UpdateUpgrades))]
+static class BTB_UpgradesController_UpdateUpgrades_Prefix
+{
+    static void Prefix(UpgradesController __instance)
+    {
+        if (__instance == null) return;
+
+        // light-touch pass
+        int relinked = BTB_UpgradesLinker.RelinkMissingPresets(__instance);
+        if (relinked > 0)
+            BTB_UpgradesLinker.LogInfo($"[BTB] Pre-UpdateUpgrades relinked {relinked} upgrade row(s).");
+    }
+}
+
+// Use the one-liner inside Setup; only skip if still null to avoid NREs.
+[HarmonyPatch(typeof(SyncDiskElementController), nameof(SyncDiskElementController.Setup))]
+static class BTB_SyncDiskElementController_Setup_Prefix
+{
+    static bool Prefix(UpgradesController.Upgrades newUpgrade)
+    {
+        // breadcrumb (debug-only)
+        BTB_UpgradesLinker.LogInfo($"[BTB] application.upgrade = '{newUpgrade?.upgrade}'");
+
+        if (newUpgrade != null)
+        {
+            var before = newUpgrade.preset;
+            BTB_LinkHelpers.LateLinkPreset(newUpgrade);
+
+            if (before == null && newUpgrade.preset != null)
+                BTB_UpgradesLinker.LogInfo($"[BTB] Late-linked preset for '{newUpgrade.upgrade}' in Setup.");
+        }
+
+        // If we still couldn't resolve it, skip to prevent NRE while diagnosing.
+        if (newUpgrade == null || newUpgrade.preset == null)
+        {
+            BTB_UpgradesLinker.LogWarn("[BTB] Skipping SyncDiskElementController.Setup: 'newUpgrade' or its 'preset' was null (preventing NRE).");
+            return false;
+        }
+
+        return true; // run the original Setup
+    }
+}
+
+// Optional: use after programmatic install/uninstall to refresh effects/state.
+public static class BTB_UpgradeEffectRefresh
+{
+    public static void ForceRefresh()
+    {
+        try
+        {
+            UpgradeEffectController._instance?.OnSyncDiskChange(true);
+            // No info logs in Release by design
+        }
+        catch (Exception ex)
+        {
+            BTB_UpgradesLinker.LogErr($"[BTB] Error forcing sync disk refresh: {ex}");
+        }
+    }
+}


### PR DESCRIPTION
# DialogControllerNullGuardPatches.cs

**v0.2.2 — Defensive crash guard for `DialogController.TestSpecialCaseAvailability(...)`**

## WHAT THIS DOES
Prevents rare NullReferenceExceptions during dialog teardown or edge transitions. Other patches (or the base game) may dereference fields like `preset.name`; when `DialogPreset` or `Citizen` is null/destroyed, that crashes the game. This patch short-circuits early and treats the option as “not available” instead of crashing, and also swallows any unexpected exceptions coming from other patches/original.

## GAME API TOUCHPOINTS

### `DialogController`
- **`TestSpecialCaseAvailability(...)` (Prefix)**: Runs **first** (`[HarmonyPriority(Priority.First)]`); if `preset` or `saysTo` is null/destroyed (Unity “truthiness”), set `__result = false` and skip the original.
- **`TestSpecialCaseAvailability(...)` (Finalizer)**: Converts any thrown exception to `__result = false` (no crash).

## HOW TO USE / TWEAK
- No configuration needed. This patch is conservative and never enables options—only prevents crashes by declining the option on bad inputs.
- Logging is error-only (release-friendly).

## COMPATIBILITY / ASSUMPTIONS
- BepInEx 6 (IL2CPP) + Harmony.
- Unity 2021.x; relies on Harmony prefix priority + finalizer behavior.
- Safe alongside other dialog patches; runs first and fails closed.

## VERSIONING / NOTES
- **0.2.2** — Prefix with Priority.First + Finalizer; error-only logging; PR-friendly header/comments.


---

# DialogControllerPatches.cs

**v0.2.2 — Guest-pass behavior: RNG by default, guaranteed success when upgraded**

## WHAT THIS DOES
Keeps vanilla randomness for requesting a Guest Pass from the on-duty crime-scene guard, **unless** the upgrade’s **`CrimeSceneGuestPass`** effect is active—in that case success is forced (deterministic). Also keeps the dialog option’s availability in sync with the base “can request pass” special case.

## GAME API TOUCHPOINTS

### `DialogController`
- **`ExecuteDialog(...)` (Prefix)**: Intercepts the **Guard Guest Pass** dialog branch.  
  - If `ForceSuccess.success/fail` is passed, honor it.  
  - Otherwise compute vanilla RNG based on social credit.  
  - **Fix**: if `ByTheBookSyncEffects.CrimeSceneGuestPass` is enabled, override to success.
- **`TestSpecialCaseAvailability(...)` (Postfix)**: Sets availability for **GuardGuestPass** only when:
  - The target is an enforcer **guarding the latest murder scene**, and
  - The base **`GuardGuestPass`** effect is enabled.

## HOW TO USE / TWEAK
- Determinism is tied strictly to the **upgrade effect**. Base disk = availability only; upgrade = guaranteed pass.
- Logging for the RNG roll can be reduced to DEBUG once verified in your environment.

## COMPATIBILITY / ASSUMPTIONS
- BepInEx 6 (IL2CPP) + Harmony.
- Uses `ByTheBookUpgradeManager` to check effects; assumes those flags reflect installed state.
- Leaves other dialog flows untouched.

## VERSIONING / NOTES
- **0.2.2** — Force success only when `CrimeSceneGuestPass` is active; base path remains RNG; availability logic retained.


---

# EnforcerTalkAccessPatches.cs

**v0.2.2 — Ensure “Talk To” appears for on-duty enforcers at active crime scenes (IL2CPP-safe)**

## WHAT THIS DOES
Some on-duty enforcers don’t expose the “Talk To” action even though their AI action map contains it. This patch promotes the **canonical Talk action** to **PRIMARY** for **on-duty** guards, but **only** when the dialog UI is not open (avoids races with “End Conversation”). Enumerates IL2CPP dictionaries directly (no System.* casts).

## GAME API TOUCHPOINTS

### `Interactable`
- **`UpdateCurrentActions()` (Postfix)**:
  - If the dialog UI is open/tearing down → **do nothing** (safety).
  - If `belongsTo` is a `Citizen` who is the **assigned guard** for an **active crime scene**:
    - Find the Talk `InteractionAction` via `aiActionReference` (IL2CPP `Dictionary<AIActionPreset, InteractionAction>`).
    - Wrap it into `Interactable.InteractableCurrentAction` and assign to `currentActions[primary]`.

### Supporting checks
- **On-duty detection**: `GameplayController.enforcerCalls` contains an entry with `isCrimeScene` and matching `guard` id.
- **Dialog-open guard**: Best-effort reflective check for `DialogController.isOpen/dialogOpen`.

## HOW TO USE / TWEAK
- Locale-agnostic match: we detect Talk by the action’s own label (`ToString().Contains("talk")`, case-insensitive). If you have a more direct API, swap it in easily.
- Error-only logging by default.

## COMPATIBILITY / ASSUMPTIONS
- BepInEx 6 (IL2CPP) + Harmony.
- Unity 2021.x; iterates `Il2CppSystem.Collections.Generic` enumerators directly (no boxing/casts to System collections).
- No changes for non-duty enforcers or when dialog is open.

## VERSIONING / NOTES
- **0.2.2** — On-duty detection, dialog-open guard, IL2CPP-safe iteration, promote canonical Talk to PRIMARY; error-only logging and documentation tidy-up.
